### PR TITLE
feat: support cc id on create payment request

### DIFF
--- a/lib/resources/payment-types.ts
+++ b/lib/resources/payment-types.ts
@@ -131,8 +131,9 @@ export namespace Payment.Cancel {
 }
 
 export type CreditCard = {
-	hash: string;
-	holder: {
+	hash?: string;
+	id?: string;
+	holder?: {
 		fullname: string;
 		birthdate?: string;
 		taxDocument: {


### PR DESCRIPTION
This feature allows the user to send only the id of a credit card already registered with Moip when making a payment.