### PR TITLE
fix: notification events type

### DIFF
--- a/lib/resources/notification-types.ts
+++ b/lib/resources/notification-types.ts
@@ -1,5 +1,5 @@
 export type NotificationPreferences = {
-	events: string;
+	events: string[];
 	target: string;
 	media: 'WEBHOOK';
 };


### PR DESCRIPTION
This hotfix changes the type of notifications events from string to string array