### PR TITLE
feat: add access token param to bank accounts requests

### DIFF
--- a/lib/resources/bank-account.ts
+++ b/lib/resources/bank-account.ts
@@ -2,17 +2,17 @@ import { HttpOpts } from '../client/types';
 import api from '../client/api';
 import * as types from './bank-account-types';
 
-const create = (opts: HttpOpts, _id: string, bankAccount: types.BankAccount) =>
-	api.post(opts, `/accounts/${_id}/bankaccounts`, bankAccount);
+const create = (opts: HttpOpts, _id: string, bankAccount: types.BankAccount, accessToken?: string) =>
+	api.post({ ...opts, auth: `OAuth ${accessToken}` }, `/accounts/${_id}/bankaccounts`, bankAccount);
 
-const getOne = (opts: HttpOpts, _id: string) =>
-	api.get(opts, '/bankaccounts', _id);
+const getOne = (opts: HttpOpts, _id: string, accessToken?: string) =>
+	api.get({ ...opts, auth: `OAuth ${accessToken}` }, '/bankaccounts', _id);
 
-const getAll = (opts: HttpOpts, _id: string) =>
-	api.get(opts, `/accounts/${_id}/bankaccounts`);
+const getAll = (opts: HttpOpts, _id: string, accessToken?: string) =>
+	api.get({ ...opts, auth: `OAuth ${accessToken}` }, `/accounts/${_id}/bankaccounts`);
 
-const remove = (opts: HttpOpts, _id: string) =>
-	api.remove(opts, `/bankaccounts/${_id}`);
+const remove = (opts: HttpOpts, _id: string, accessToken?: string) =>
+	api.remove({ ...opts, auth: `OAuth ${accessToken}` }, `/bankaccounts/${_id}`);
 
 export default {
 	create: create as unknown as OmitFirstArg<typeof create>,


### PR DESCRIPTION
This feature allows a primary to create, list, or remove bank accounts from a secondary by passing the access token.